### PR TITLE
Use caret version in npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,11 +66,11 @@
     "tslib": "1.5.0"
   },
   "dependencies": {
-    "phovea_core": "~2.0.0",
-    "phovea_vis": "~2.0.0",
-    "phovea_d3": "~2.0.0",
-    "phovea_ui": "~2.0.0",
-    "phovea_clue": "~2.0.0"
+    "phovea_core": "^2.0.0",
+    "phovea_vis": "^2.0.0",
+    "phovea_d3": "^2.0.0",
+    "phovea_ui": "^2.0.0",
+    "phovea_clue": "^2.0.0"
   },
   "name": "gapminder",
   "description": "",


### PR DESCRIPTION
Requires https://github.com/phovea/generator-phovea/pull/161

Reverts 8abaa4ebd23adf3828663aae1a3b68150327c3be
