### PR TITLE
Update to Python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/phovea
     docker:
-      - image: circleci/node:12-browsers
+      - image: circleci/node:12.13-buster-browsers
     steps:
       - checkout
       - run:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-- 6
+- 12.13
 
 addons:
   firefox: 49.0.1


### PR DESCRIPTION
### Summary

* use `circleci/node:12.13-buster-browsers` as Docker image
* update `node.js` in _.travis.yml_